### PR TITLE
Convert SocketPort(int) to SocketListenStream(string) to allow using IP

### DIFF
--- a/service.go
+++ b/service.go
@@ -120,10 +120,10 @@ type Config struct {
 	Option KeyValue
 
 	// Optional field to generate a socket file
-	WithSocket        bool   // Create socket file.
-	SocketDescription string // Long description of socket.
-	SocketPort        int    // Socket ListenStream port.
-	SocketPartOf      string // Socket PartOf to stop socket when main service is manually stopped; value is service name (Name.service)
+	WithSocket         bool   // Create socket file.
+	SocketDescription  string // Long description of socket.
+	SocketListenStream string // Socket ListenStream.
+	SocketPartOf       string // Socket PartOf to stop socket when main service is manually stopped; value is service name (Name.service)
 }
 
 var (

--- a/service_systemd_linux.go
+++ b/service_systemd_linux.go
@@ -222,6 +222,6 @@ Description={{.SocketDescription}}
 {{if .SocketPartOf}}PartOf={{.SocketPartOf}}{{end}}
 
 [Socket]
-ListenStream={{.SocketPort}}
+ListenStream={{.SocketListenStream}}
 NoDelay=true
 `


### PR DESCRIPTION
address to force ipv4.

https://www.freedesktop.org/software/systemd/man/systemd.socket.html

'If the address string is a string in the format "v.w.x.y:z", it is
interpreted as IPv4 address v.w.x.y and port z.'